### PR TITLE
Return full application.json on POSTing /apps

### DIFF
--- a/api_service/app.py
+++ b/api_service/app.py
@@ -56,7 +56,7 @@ def create_application():
 
     try:
         result = configdb[app_collection].insert_one(app_json)
-        response = jsonify(data=app_id)
+        response = jsonify(data=app_json)
         response.status_code = 200
         return response
     except InvalidOperation:


### PR DESCRIPTION
In the analyzer API spec, we defined in POST /v1/apps that, the success response is "application.json" with unique app_id, therefore changing the API to return full app document instead of a single ID.